### PR TITLE
Correct argument name to reflect instructions

### DIFF
--- a/cfimp.js
+++ b/cfimp.js
@@ -32,7 +32,7 @@
 		'env',
 		'space',
 		'preview',
-		'filepreview',
+		'previewfile',
 		'publish',
 		'skipfields',
 		'offset',
@@ -226,7 +226,7 @@
 			fs.writeFile(jsonFileName, JSON.stringify(data), encoding, err => !err ? res() : rej(err));
 		});
 	} catch(e) { return console.error(cnslCols.red, e); }
-	if (args.filepreview)
+	if (args.previewfile)
 		return console.info(cnslCols.blue, 'Notice: quit early just to build Contentful import file for preview purposes; file is '+jsonFileName);
 
 	//run import - delete JSON file after


### PR DESCRIPTION
All documentation refers to the `previewfile` argument, but in the code it was `filepreview` which caused an "unknown argument" result when using the tool according to the instructions provided. This PR amends to code to reflect the instructions.